### PR TITLE
Add back BepInEx project sources into LethalAPI.Core.csproj

### DIFF
--- a/LethalAPI.Core/LethalAPI.Core.csproj
+++ b/LethalAPI.Core/LethalAPI.Core.csproj
@@ -9,6 +9,11 @@
         <DebugType>embedded</DebugType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
+        <RestoreAdditionalProjectSources>
+            https://api.nuget.org/v3/index.json;
+            https://nuget.bepinex.dev/v3/index.json;
+            https://nuget.samboy.dev/v3/index.json
+        </RestoreAdditionalProjectSources>
         <DocumentationFile>..\bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LethalAPI.ruleset</CodeAnalysisRuleSet>
         <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/LethalAPI.Core/LethalAPI.Core.csproj
+++ b/LethalAPI.Core/LethalAPI.Core.csproj
@@ -11,8 +11,7 @@
         <LangVersion>latest</LangVersion>
         <RestoreAdditionalProjectSources>
             https://api.nuget.org/v3/index.json;
-            https://nuget.bepinex.dev/v3/index.json;
-            https://nuget.samboy.dev/v3/index.json
+            https://nuget.bepinex.dev/v3/index.json
         </RestoreAdditionalProjectSources>
         <DocumentationFile>..\bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LethalAPI.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
Seems like for fresh clones of the repo, the BepInEx dependencies will not always resolve properly without the project sources added by the BepInEx template.