### PR TITLE
Improve Event Transpiler Helpers

### DIFF
--- a/LethalAPI.Core/Patches/Events/Player/PlayerHealingInjuringTranspiler.cs
+++ b/LethalAPI.Core/Patches/Events/Player/PlayerHealingInjuringTranspiler.cs
@@ -18,8 +18,6 @@ using HarmonyTools;
 using LethalAPI.Core.Events.Attributes;
 using LethalAPI.Core.Events.EventArgs.Player;
 
-using static AccessTools;
-
 /// <summary>
 ///     Patches the <see cref="HandlersPlayer.Healing"/> and <see cref="HandlersPlayer.CriticallyInjure"/> event.
 /// </summary>
@@ -28,8 +26,6 @@ using static AccessTools;
 [EventPatch(typeof(HandlersPlayer), nameof(HandlersPlayer.Healing))]
 internal static class PlayerHealingInjuringTranspiler
 {
-    private static readonly FieldInfo CriticallyInjuredField = Field(typeof(PlayerControllerB), nameof(PlayerControllerB.criticallyInjured));
-
     [HarmonyTranspiler]
     private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator, MethodBase original)
     {

--- a/LethalAPI.Core/Patches/HarmonyTools/EventTranspilerInjector.cs
+++ b/LethalAPI.Core/Patches/HarmonyTools/EventTranspilerInjector.cs
@@ -166,7 +166,16 @@ public static class EventTranspilerInjector
                     continue;
                 }
 
-                parameterStack.Insert(parameterStack.Count, new CodeInstruction(OpCodes.Ldarg_S, j));
+                CodeInstruction instruction = (j + (originalMethod.IsStatic ? 0 : 1)) switch
+                    {
+                        0 => new CodeInstruction(OpCodes.Ldarg_0),
+                        1 => new CodeInstruction(OpCodes.Ldarg_1),
+                        2 => new CodeInstruction(OpCodes.Ldarg_2),
+                        3 => new CodeInstruction(OpCodes.Ldarg_3),
+                        var n => new CodeInstruction(OpCodes.Ldarg_S, n),
+                    };
+
+                parameterStack.Insert(parameterStack.Count, instruction);
             }
         }
 


### PR DESCRIPTION
Improving the event transpiling/patching system a bit

Fixed the following issues:
* Classes annotated with multiple `EventPatch` attributes were getting their patches applied twice with dynamic patching
* `EventTranspilerInjector.InjectDeniableEvent` was generating the wrong IL code for the existing player events
  * Broke up the method into internal sub methods (planned to be used for `CodeMatcher` extensions as well
  * Properly copy labels onto new instruction so branching is preserved
* The `CriticallyInjure` and `Healing` events were not being transpiled correctly
  * They now emit correctly when being critically injured and healed back from critical

**Event Example**

Given the following handlers:
```c#
        Events.Handlers.Player.CriticallyInjure += @event =>
        {
            Log.Info($"Player {@event.Player.playerUsername} is being critically injured.");
            Log.Info($"Health: {@event.Player.health}");
        };
        Events.Handlers.Player.Healing += @event =>
        {
            Log.Info($"Player {@event.Player.playerUsername} is being healed.");
            Log.Info($"Health: {@event.Player.health}");
        };
 ```

We see the following output when taking damage which drops health below 10:
```
[11/18/2023 1:54 AM (08.339s)] [Info] [LethalAPI.Core] Player dhkatz is being critically injured.
[11/18/2023 1:54 AM (08.342s)] [Info] [LethalAPI.Core] Health: 5
```

After waiting a bit we are healed back up to 20 and are no longer critically injured:
```
[11/18/2023 1:54 AM (22.575s)] [Info] [LethalAPI.Core] Player dhkatz is being healed.
[11/18/2023 1:54 AM (22.579s)] [Info] [LethalAPI.Core] Health: 20
```