### PR TITLE
Fix dynamic patching

### DIFF
--- a/LethalAPI.Core/Events/Attributes/IgnorePatch.cs
+++ b/LethalAPI.Core/Events/Attributes/IgnorePatch.cs
@@ -1,0 +1,18 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IgnorePatch.cs" company="LethalAPI Modding Community">
+// Copyright (c) LethalAPI Modding Community. All rights reserved.
+// Licensed under the GPL-3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace LethalAPI.Core.Events.Attributes;
+
+using System;
+
+/// <summary>
+/// Indicates to the <see cref="Features.Patcher"/> to not patch a class.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+internal sealed class IgnorePatch : Attribute
+{
+}

--- a/LethalAPI.Core/Events/Features/Patcher.cs
+++ b/LethalAPI.Core/Events/Features/Patcher.cs
@@ -198,7 +198,10 @@ public class Patcher
                 if (type.GetCustomAttribute<HarmonyPatch>() is null)
                     continue;
 
-                if (!type.GetCustomAttributes<EventPatchAttribute>().Any())
+                if (type.GetCustomAttributes<EventPatchAttribute>().Any())
+                    continue;
+
+                if (type.GetCustomAttributes<EventPatchAttribute>().Any())
                     continue;
 
                 types.Add(type);

--- a/LethalAPI.Core/Patches/Fixes/FixBepInExLoggerPrefix.cs
+++ b/LethalAPI.Core/Patches/Fixes/FixBepInExLoggerPrefix.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Text;
 
 using BepInEx.Logging;
+using Core.Events.Attributes;
 
 #pragma warning disable SA1402
 #pragma warning disable SA1313
@@ -26,6 +27,7 @@ using BepInEx.Logging;
 // ReSharper disable UnusedParameter.Local
 // This now is called manually in the plugin loader.
 // [HarmonyPatch(typeof(ConsoleLogListener), nameof(ConsoleLogListener.LogEvent))]
+[IgnorePatch]
 internal static class FixBepInExLoggerPrefix
 {
     /// <inheritdoc cref ="Core.Log.ColorCodes" />


### PR DESCRIPTION
Fixes a bug where dynamic patching only patches events. This is the opposite behavior of what should occur and is due to something I overlooked when switching a linq expression to a foreach + list expression. Previously it would only include if an element is not present, but I switched it to continue without adding the list.

This seems to fix the problem.